### PR TITLE
Fix the use of missing symbols with MinGW

### DIFF
--- a/3rdparty/breakpad/client/windows/handler/exception_handler.cc
+++ b/3rdparty/breakpad/client/windows/handler/exception_handler.cc
@@ -281,10 +281,10 @@ void ExceptionHandler::Initialize(
     if (handler_types & HANDLER_EXCEPTION)
       previous_filter_ = SetUnhandledExceptionFilter(HandleException);
 
-//#if _MSC_VER >= 1400  // MSVC 2005/8
+#if _MSC_VER >= 1400  // MSVC 2005/8
     if (handler_types & HANDLER_INVALID_PARAMETER)
       previous_iph_ = _set_invalid_parameter_handler(HandleInvalidParameter);
-//#endif  // _MSC_VER >= 1400
+#endif  // _MSC_VER >= 1400
 
     if (handler_types & HANDLER_PURECALL)
       previous_pch_ = _set_purecall_handler(HandlePureVirtualCall);
@@ -308,10 +308,10 @@ ExceptionHandler::~ExceptionHandler() {
     if (handler_types_ & HANDLER_EXCEPTION)
       SetUnhandledExceptionFilter(previous_filter_);
 
-//#if _MSC_VER >= 1400  // MSVC 2005/8
+#if _MSC_VER >= 1400  // MSVC 2005/8
     if (handler_types_ & HANDLER_INVALID_PARAMETER)
       _set_invalid_parameter_handler(previous_iph_);
-//#endif  // _MSC_VER >= 1400
+#endif  // _MSC_VER >= 1400
 
     if (handler_types_ & HANDLER_PURECALL)
       _set_purecall_handler(previous_pch_);
@@ -531,7 +531,7 @@ LONG ExceptionHandler::HandleException(EXCEPTION_POINTERS* exinfo) {
   return action;
 }
 
-//#if _MSC_VER >= 1400  // MSVC 2005/8
+#if _MSC_VER >= 1400  // MSVC 2005/8
 // static
 void ExceptionHandler::HandleInvalidParameter(const wchar_t* expression,
                                               const wchar_t* function,
@@ -624,7 +624,7 @@ void ExceptionHandler::HandleInvalidParameter(const wchar_t* expression,
   // the behavior of "swallowing" exceptions.
   exit(0);
 }
-//#endif  // _MSC_VER >= 1400
+#endif  // _MSC_VER >= 1400
 
 // static
 void ExceptionHandler::HandlePureVirtualCall() {

--- a/3rdparty/breakpad/client/windows/handler/exception_handler.h
+++ b/3rdparty/breakpad/client/windows/handler/exception_handler.h
@@ -307,7 +307,7 @@ class ExceptionHandler {
   // Signals the exception handler thread to handle the exception.
   static LONG WINAPI HandleException(EXCEPTION_POINTERS* exinfo);
 
-// #if _MSC_VER >= 1400  // MSVC 2005/8
+#if _MSC_VER >= 1400  // MSVC 2005/8
   // This function will be called by some CRT functions when they detect
   // that they were passed an invalid parameter.  Note that in _DEBUG builds,
   // the CRT may display an assertion dialog before calling this function,
@@ -318,7 +318,7 @@ class ExceptionHandler {
                                      const wchar_t* file,
                                      unsigned int line,
                                      uintptr_t reserved);
-// #endif  // _MSC_VER >= 1400
+#endif  // _MSC_VER >= 1400
 
   // This function will be called by the CRT when a pure virtual
   // function is called.


### PR DESCRIPTION
swprintf_s isn't available in msvcrt.dll on WinXP and
MinGW is linking directly to the OS version instead of
using the versioned msvcrtXXX.dll.

Disable the HANDLER_INVALID_PARAMETER handler in favor of
keeping XP support.