### PR TITLE
Add libdisasm license, allow disabling GUI component

### DIFF
--- a/3rdparty/breakpad/third_party/libdisasm/LICENSE
+++ b/3rdparty/breakpad/third_party/libdisasm/LICENSE
@@ -1,0 +1,137 @@
+
+
+
+
+			 The "Clarified Artistic License"
+
+				Preamble
+
+The intent of this document is to state the conditions under which a
+Package may be copied, such that the Copyright Holder maintains some
+semblance of artistic control over the development of the package,
+while giving the users of the package the right to use and distribute
+the Package in a more-or-less customary fashion, plus the right to make
+reasonable modifications.
+
+Definitions:
+
+	"Package" refers to the collection of files distributed by the
+	Copyright Holder, and derivatives of that collection of files
+	created through textual modification.
+
+	"Standard Version" refers to such a Package if it has not been
+	modified, or has been modified in accordance with the wishes
+	of the Copyright Holder as specified below.
+
+	"Copyright Holder" is whoever is named in the copyright or
+	copyrights for the package.
+
+	"You" is you, if you're thinking about copying or distributing
+	this Package.
+
+	"Distribution fee" is a fee you charge for providing a copy of this
+	Package to another party.
+
+	"Freely Available" means that no fee is charged for the right to use
+	the item, though there may be fees involved in handling the item.
+
+1. You may make and give away verbatim copies of the source form of the
+Standard Version of this Package without restriction, provided that you
+duplicate all of the original copyright notices and associated disclaimers.
+
+2. You may apply bug fixes, portability fixes and other modifications
+derived from the Public Domain, or those made Freely Available, or from
+the Copyright Holder.  A Package modified in such a way shall still be
+considered the Standard Version.
+
+3. You may otherwise modify your copy of this Package in any way, provided
+that you insert a prominent notice in each changed file stating how and
+when you changed that file, and provided that you do at least ONE of the
+following:
+
+    a) place your modifications in the Public Domain or otherwise make them
+    Freely Available, such as by posting said modifications to Usenet or
+    an equivalent medium, or placing the modifications on a major archive
+    site allowing unrestricted access to them, or by allowing the Copyright
+    Holder to include your modifications in the Standard Version of the
+    Package.
+
+    b) use the modified Package only within your corporation or organization.
+
+    c) rename any non-standard executables so the names do not conflict
+    with standard executables, which must also be provided, and provide
+    a separate manual page for each non-standard executable that clearly
+    documents how it differs from the Standard Version.
+
+    d) make other distribution arrangements with the Copyright Holder.
+
+    e) permit and encourge anyone who receives a copy of the modified Package
+    permission to make your modifications Freely Available in some specific
+    way.
+
+4. You may distribute the programs of this Package in object code or
+executable form, provided that you do at least ONE of the following:
+
+    a) distribute a Standard Version of the executables and library files,
+    together with instructions (in the manual page or equivalent) on where
+    to get the Standard Version.
+
+    b) accompany the distribution with the machine-readable source of
+    the Package with your modifications.
+
+    c) give non-standard executables non-standard names, and clearly
+    document the differences in manual pages (or equivalent), together
+    with instructions on where to get the Standard Version.
+
+    d) make other distribution arrangements with the Copyright Holder.
+
+    e) offer the machine-readable source of the Package, with your
+    modifications, by mail order.
+
+5. You may charge a distribution fee for any distribution of this Package.
+If you offer support for this Package, you may charge any fee you choose
+for that support.  You may not charge a license fee for the right to use
+this Package itself.  You may distribute this Package in aggregate with
+other (possibly commercial and possibly nonfree) programs as part of a
+larger (possibly commercial and possibly nonfree) software distribution,
+and charge license fees for other parts of that software distribution,
+provided that you do not advertise this Package as a product of your own.
+If the Package includes an interpreter, You may embed this Package's
+interpreter within an executable of yours (by linking); this shall be
+construed as a mere form of aggregation, provided that the complete
+Standard Version of the interpreter is so embedded.
+
+6. The scripts and library files supplied as input to or produced as
+output from the programs of this Package do not automatically fall
+under the copyright of this Package, but belong to whoever generated
+them, and may be sold commercially, and may be aggregated with this
+Package.  If such scripts or library files are aggregated with this
+Package via the so-called "undump" or "unexec" methods of producing a
+binary executable image, then distribution of such an image shall
+neither be construed as a distribution of this Package nor shall it
+fall under the restrictions of Paragraphs 3 and 4, provided that you do
+not represent such an executable image as a Standard Version of this
+Package.
+
+7. C subroutines (or comparably compiled subroutines in other
+languages) supplied by you and linked into this Package in order to
+emulate subroutines and variables of the language defined by this
+Package shall not be considered part of this Package, but are the
+equivalent of input as in Paragraph 6, provided these subroutines do
+not change the language in any way that would cause it to fail the
+regression tests for the language.
+
+8. Aggregation of the Standard Version of the Package with a commercial
+distribution is always permitted provided that the use of this Package is
+embedded; that is, when no overt attempt is made to make this Package's
+interfaces visible to the end user of the commercial distribution.
+Such use shall not be construed as a distribution of this Package.
+
+9. The name of the Copyright Holder may not be used to endorse or promote
+products derived from this software without specific prior written permission.
+
+10. THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+				The End

--- a/3rdparty/breakpad/third_party/libdisasm/README.breakpad
+++ b/3rdparty/breakpad/third_party/libdisasm/README.breakpad
@@ -1,0 +1,9 @@
+Name: libdisasm
+URL: https://sourceforge.net/projects/bastard/files/libdisasm/0.23/libdisasm-0.23.tar.gz/download
+Version: 0.23
+License: Clarified-Artistic
+License File: LICENSE
+
+Description:
+This contains a copy of libdisasm.  It is no longer under development upstream,
+so we keep a copy here to maintain fixes ourselves.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ if(POLICY CMP0071)
     cmake_policy(SET CMP0071 NEW)
 endif()
 
-option(ENABLE_GPL_CODE OFF)
+option(ENABLE_GPL_CODE "Enable GPL-licensed depencencies of libcrashreporter-qt (dr.konqui integration)" OFF)
+option(ENABLE_CRASH_REPORTER "Enable libcrashreporter-qt GUI component" ON)
 
 find_package(Qt5 COMPONENTS Core Network Widgets)
 
@@ -17,6 +18,10 @@ if((CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_FLAGS) OR
     string(REPLACE "-std=c++11" "-std=gnu++11" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
     string(REPLACE "-std=c++14" "-std=gnu++14" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif()
+
+if(ENABLE_CRASH_REPORTER)
+    add_definitions(-DENABLE_CRASH_REPORTER)
+endif(ENABLE_CRASH_REPORTER)
 
 add_subdirectory(3rdparty)
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_subdirectory(libcrashreporter-handler)
-add_subdirectory(libcrashreporter-gui)
+
+if (ENABLE_CRASH_REPORTER)
+    add_subdirectory(libcrashreporter-gui)
+endif(ENABLE_CRASH_REPORTER)

--- a/src/libcrashreporter-handler/Handler.cpp
+++ b/src/libcrashreporter-handler/Handler.cpp
@@ -249,7 +249,7 @@ Handler::Handler( const QString& dumpFolderPath, bool active, const QString& cra
     m_crash_handler =  new google_breakpad::ExceptionHandler( dumpFolderPath.toStdString(), NULL, LaunchUploader, this, true, NULL);
     #elif defined Q_OS_WIN
 //     m_crash_handler = new google_breakpad::ExceptionHandler( dumpFolderPath.toStdString(), 0, LaunchUploader, this, true, 0 );
-    m_crash_handler = new google_breakpad::ExceptionHandler( dumpFolderPath.toStdWString(), 0, LaunchUploader, this, true, 0 );
+    m_crash_handler = new google_breakpad::ExceptionHandler( dumpFolderPath.toStdWString(), 0, LaunchUploader, this, google_breakpad::ExceptionHandler::HANDLER_ALL );
     #endif
 
     setCrashReporter( crashReporter );

--- a/src/libcrashreporter-handler/Handler.cpp
+++ b/src/libcrashreporter-handler/Handler.cpp
@@ -218,7 +218,7 @@ LaunchUploader( const char* dump_dir, const char* minidump_id, void* context, bo
         printf( "Error: Can't launch CrashReporter!\n" );
         return false;
     }
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) && defined(ENABLE_CRASH_REPORTER)
     // If we're running on Linux, we expect that the CrashReporter component will
     // attach gdb, do its thing and then kill this process, so we hang here for the
     // time being, on purpose.          -- Teo 3/2016


### PR DESCRIPTION
This pull request contains changes that are required for usage of this library in [MuseScore](https://github.com/musescore/MuseScore/pull/4679) project and may, hopefully, help others to make use of it too.

The proposed changes are:
 1) Add a license information for libdisasm, as [suggested](https://github.com/musescore/MuseScore/pull/4679#issuecomment-464107525) by @mirabilos.
 2) Add an option to disable crash reporter GUI component built into libcrashreporter-qt so that only the crash handler itself is built. The reasons to disable it in some situations are:
-- Strict requirement for dr. konqui integration on Linux;
-- Restrictions for the server configuration (for example, the crash reporter assumes that the server would assign an ID for the crash report and send it in its reply).

I also added description strings for the options, mainly because [it is required](https://cmake.org/cmake/help/v3.0/command/option.html) by CMake itself to work properly. The default option value is always the third `option()` argument so the `option(ENABLE_CRASH_REPORTER ON)` line would, interestingly, set this option to `OFF`. If the proposed descriptions are not accurate feel free to ask me to change them (or replace them with empty strings).