### PR TITLE
Make copying crash ID simple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ if(POLICY CMP0071)
     cmake_policy(SET CMP0071 NEW)
 endif()
 
+if(POLICY CMP0063)
+    cmake_policy(SET CMP0063 NEW)
+endif()
+
 option(ENABLE_GPL_CODE "Enable GPL-licensed depencencies of libcrashreporter-qt (dr.konqui integration)" OFF)
 option(ENABLE_CRASH_REPORTER "Enable libcrashreporter-qt GUI component" ON)
 

--- a/src/libcrashreporter-gui/CrashReporter.h
+++ b/src/libcrashreporter-gui/CrashReporter.h
@@ -77,6 +77,7 @@ private slots:
     void onProgress( qint64 done, qint64 total );
     void onFail( int error, const QString& errorString );
     void onSendButton();
+    void onLinkClicked(const QString& link);
 };
 
 #endif // CRASHREPORTER_H


### PR DESCRIPTION
This PR implements what was suggested in https://github.com/owncloud/client/issues/8130:

![screenshot_2021-03-12_23-45-20](https://user-images.githubusercontent.com/80399010/111006422-aa3d5500-8384-11eb-9766-e0300dfd02aa.png)

The ID is a clickable link. The corresponding click handler copies the ID into the user's clipboard. It seemed like the easiest way to integrate this feature in the current UX, otherwise a button would need to be added somewhere. Alternatives would've been a context menu entry, or making the entire label clickable.

The PR also contains a commit that fixes a CMake policy warning, making the project compatible with the latest CMake releases.

Note that I could not compile the library without patching `breakpad`, which used a `struct ucontext` that doesn't seem to exist in both the system `ucontext.h` and `sys/ucontext.h` and the bundled headers. Instead, a `ucontext_t` is `typedef`'d directly from said struct. In order to make the compiler happy (i.e., provide its full definition), I had to swap all occurrences of `struct ucontext` with `ucontext_t`. I might have to file a second PR to fix this, but I'm not sure why this only seems to affect my own build.