### PR TITLE
Remove deprecated register keyword

### DIFF
--- a/3rdparty/breakpad/client/mac/handler/breakpad_nlist_64.cc
+++ b/3rdparty/breakpad/client/mac/handler/breakpad_nlist_64.cc
@@ -281,7 +281,7 @@ int __breakpad_fdnlist(int fd, nlist_type *list, const char **symbolNames,
 
   off_t sa;  /* symbol address */
   off_t ss;  /* start of strings */
-  register register_t n;
+  register_t n;
   if (*((unsigned int *)&buf) == magic) {
     if (lseek(fd, arch_offset, SEEK_SET) == -1) {
       return -1;
@@ -354,7 +354,7 @@ int __breakpad_fdnlist(int fd, nlist_type *list, const char **symbolNames,
   // and look for a match
   while (n) {
     nlist_type space[BUFSIZ/sizeof (nlist_type)];
-    register register_t m = sizeof (space);
+    register_t m = sizeof (space);
 
     if (n < m)
       m = n;

--- a/3rdparty/breakpad/common/dwarf/dwarf2reader.cc
+++ b/3rdparty/breakpad/common/dwarf/dwarf2reader.cc
@@ -874,7 +874,7 @@ class CallFrameInfo::Rule {
   // describes how to compute the canonical frame address. Return what the
   // HANDLER member function returned.
   virtual bool Handle(Handler *handler,
-                      uint64 address, int register) const = 0;
+                      uint64 address, int _register) const = 0;
 
   // Equality on rules. We use these to decide which rules we need
   // to report after a DW_CFA_restore_state instruction.

--- a/3rdparty/breakpad/common/md5.cc
+++ b/3rdparty/breakpad/common/md5.cc
@@ -166,7 +166,7 @@ void MD5Final(unsigned char digest[16], struct MD5Context *ctx)
  */
 static void MD5Transform(u32 buf[4], u32 const in[16])
 {
-  register u32 a, b, c, d;
+  u32 a, b, c, d;
 
   a = buf[0];
   b = buf[1];


### PR DESCRIPTION
The keyword register is deprecated and removed with c++17